### PR TITLE
DE26018 - First element should not be focused on click

### DIFF
--- a/d2l-user-switcher.html
+++ b/d2l-user-switcher.html
@@ -106,7 +106,7 @@
 			</template>
 			<template is="dom-if" if="[[multipleUsers]]">
 				<d2l-dropdown>
-					<button class="d2l-user-switcher-opener-container pointer d2l-dropdown-opener" aria-label$="[[localize('switchUser', 'name', _name)]]">
+					<button class="d2l-user-switcher-opener-container pointer d2l-dropdown-opener" on-mouseenter="_disableFocusOnClick" on-mouseleave="_enableFocusOnClick" aria-label$="[[localize('switchUser', 'name', _name)]]">
 						<d2l-icon
 							icon="d2l-tier3:profile-pic"
 							class="user-tile-default-icon d2l-user-switcher-opener-image">
@@ -179,6 +179,10 @@
 					type: String,
 					value: null,
 					observer: '_onNameChanged'
+				},
+				_focusOnClick: {
+					type: Boolean,
+					value: false
 				}
 			},
 
@@ -211,9 +215,20 @@
 
 			onOpen: function() {
 				var self = this;
-				setTimeout(function() {
-					self.$$('d2l-menu').focus();
-				}, 0);
+
+				if (self._focusOnClick) {
+					setTimeout(function() {
+						self.$$('d2l-menu').focus();
+					}, 0);
+				}
+			},
+
+			_disableFocusOnClick: function() {
+				this._focusOnClick = false;
+			},
+
+			_enableFocusOnClick: function() {
+				this._focusOnClick = true;
 			},
 
 			_onIconUrlChanged: function(iconUrl) {


### PR DESCRIPTION
[Defect](https://rally1.rallydev.com/#/89963236876d/detail/defect/117680797564?fdp=true)

First `user-switcher-item` should not be focused if entering dropdown through a mouse click. Still gets focus if entering through keyboard.