### PR TITLE
Bump user profile behavior/ifrau versions

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,7 +24,7 @@
     "d2l-icons": "^3.6.0",
     "d2l-image": "git://github.com/Brightspace/d2l-image#^1.0.0",
     "d2l-menu": "^0.3.0",
-    "d2l-user-profile-behavior": "git://github.com/Brightspace/user-profile-behavior#^1.0.5",
+    "d2l-user-profile-behavior": "git://github.com/Brightspace/user-profile-behavior#^2.0.0",
     "polymer": "^1.8.0",
     "iron-icon": "^1.0.13"
   },

--- a/d2l-user-switcher-item.html
+++ b/d2l-user-switcher-item.html
@@ -68,7 +68,7 @@
 			</div>
 		</a>
 	</template>
-	<script src="https://s.brightspace.com/lib/ifrau/0.19.0/ifrau/client.js"></script>
+	<script src="https://s.brightspace.com/lib/ifrau/0.20.0/ifrau/client.js"></script>
 	<script>
 		'use strict';
 

--- a/d2l-user-switcher.html
+++ b/d2l-user-switcher.html
@@ -137,7 +137,7 @@
 			</template>
 		</template>
 	</template>
-	<script src="https://s.brightspace.com/lib/ifrau/0.19.0/ifrau/client.js"></script>
+	<script src="https://s.brightspace.com/lib/ifrau/0.20.0/ifrau/client.js"></script>
 	<script>
 		'use strict';
 


### PR DESCRIPTION
Bump d2l-user-profile-behavior to a new version which uses fetch/promises, which allows consuming apps/elements that use fetch middleware (eg. dedupe) to perform optimizations on identical fetch calls.

Also bumps ifrau client version to v0.20.0, which while not the brand-newest, is what parent-portal-ui (currently the only consuming app) uses - so may as well avoid an unnecessary script download.