### PR TITLE
fix master build version conflict

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -26,7 +26,8 @@
     "d2l-menu": "^0.3.0",
     "d2l-user-profile-behavior": "git://github.com/Brightspace/user-profile-behavior#^2.0.0",
     "polymer": "^1.8.0",
-    "iron-icon": "^1.0.13"
+    "iron-icon": "^1.0.13",
+    "webcomponentsjs": "^0.7.24"
   },
   "devDependencies": {
     "d2l-demo-template": "^0.0.12",

--- a/bower.json
+++ b/bower.json
@@ -26,7 +26,9 @@
     "d2l-menu": "^0.3.0",
     "d2l-user-profile-behavior": "git://github.com/Brightspace/user-profile-behavior#^2.0.0",
     "polymer": "^1.8.0",
-    "iron-icon": "^1.0.13",
+    "iron-icon": "^1.0.13"
+  },
+  "resolutions": {
     "webcomponentsjs": "^0.7.24"
   },
   "devDependencies": {


### PR DESCRIPTION
My user switcher tests PR has broken master. It can't resolve `webcomponentsjs`. This _should_ fix it, but it has never broken on a PR branch or on my local instance so I am basically going in blind.