### PR TITLE
revert removal of d2l-image

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,6 +22,7 @@
     "d2l-dropdown": "^6.0.0",
     "d2l-hm-constants-behavior": "Brightspace/d2l-hm-constants-behavior#^5.0.0",
     "d2l-icons": "^5.0.0",
+    "d2l-image": "Brightspace/d2l-image#^2.0.0",
     "d2l-menu": "^1.0.0",
     "d2l-user-profile-behavior": "Brightspace/user-profile-behavior#^3.0.1",
     "ifrau-import": "Brightspace/ifrau-import#^1.0.0",

--- a/d2l-user-switcher-item.html
+++ b/d2l-user-switcher-item.html
@@ -3,6 +3,7 @@
 <link rel="import" href="../d2l-menu/d2l-menu-item-behavior.html">
 <link rel="import" href="../d2l-menu/d2l-menu-item-styles.html">
 <link rel="import" href="../d2l-colors/d2l-colors.html">
+<link rel="import" href="../d2l-image/d2l-image.html">
 <link rel="import" href="../d2l-user-profile-behavior/d2l-user-profile-behavior.html">
 <link rel="import" href="../ifrau-import/ifrau-client.html">
 
@@ -57,10 +58,12 @@
 				icon="d2l-tier3:profile-pic"
 				class="user-tile-default-icon d2l-user-switcher-item-image">
 			</d2l-icon>
-			<img
+			<d2l-image
 				hidden$="[[!_hidePlaceholderIcon(_iconUrl)]]"
-				src="[[_iconUrl]]"
-				class="d2l-user-switcher-item-image" />
+				image-url="[[_iconUrl]]"
+				token="[[token]]"
+				class="d2l-user-switcher-item-image">
+			</d2l-image>
 			<div class="d2l-user-switcher-item-info">
 				<p class="d2l-user-switcher-item-name">[[_name]]</p>
 			</div>

--- a/d2l-user-switcher.html
+++ b/d2l-user-switcher.html
@@ -4,6 +4,7 @@
 <link rel="import" href="../d2l-dropdown/d2l-dropdown-menu.html">
 <link rel="import" href="../d2l-hm-constants-behavior/d2l-hm-constants-behavior.html">
 <link rel="import" href="../d2l-icons/d2l-icons.html">
+<link rel="import" href="../d2l-image/d2l-image.html">
 <link rel="import" href="../ifrau-import/ifrau-client.html">
 <link rel="import" href="../d2l-menu/d2l-menu.html">
 <link rel="import" href="../d2l-menu/d2l-menu-item.html">
@@ -80,7 +81,7 @@
 				display: none;
 			}
 			d2l-icon,
-			.d2l-user-switcher-opener-image {
+			d2l-image {
 				transition: opacity 250ms;
 			}
 			.opaque {
@@ -98,10 +99,12 @@
 						icon="d2l-tier3:profile-pic"
 						class="user-tile-default-icon d2l-user-switcher-opener-image opaque">
 					</d2l-icon>
-					<img
+					<d2l-image
 						hidden
-						src="[[_iconUrl]]"
-						class="d2l-user-switcher-opener-image transparent" />
+						image-url="[[_iconUrl]]"
+						token="[[token]]"
+						class="d2l-user-switcher-opener-image transparent">
+					</d2l-image>
 					<p hidden$="[[!placeholders]]" class="text-placeholder">&nbsp;</p>
 					<p hidden$="[[placeholders]]" class="selected-user-name">[[_name]]</p>
 				</div>
@@ -113,10 +116,12 @@
 							icon="d2l-tier3:profile-pic"
 							class="user-tile-default-icon d2l-user-switcher-opener-image">
 						</d2l-icon>
-						<img
+						<d2l-image
 							hidden
-							src="[[_iconUrl]]"
-							class="d2l-user-switcher-opener-image" />
+							image-url="[[_iconUrl]]"
+							token="[[token]]"
+							class="d2l-user-switcher-opener-image">
+						</d2l-image>
 						<p hidden$="[[!placeholders]]" class="text-placeholder">&nbsp;</p>
 						<p hidden$="[[placeholders]]" class="selected-user-name">[[_name]]</p>
 						<d2l-icon class="d2l-user-switcher-opener-chevron-down" icon="d2l-tier1:chevron-down"></d2l-icon>
@@ -232,7 +237,7 @@
 
 			_onIconUrlChanged: function(iconUrl) {
 				var icon = this.multipleUsers ? this.$$('d2l-dropdown d2l-icon') : this.$$('d2l-icon');
-				var image = this.multipleUsers ? this.$$('d2l-dropdown img') : this.$$('img');
+				var image = this.multipleUsers ? this.$$('d2l-dropdown d2l-image') : this.$$('d2l-image');
 
 				if (iconUrl) {
 					icon.toggleClass('transparent', true);
@@ -241,7 +246,7 @@
 						image.removeAttribute('hidden');
 					}, 250);
 					setTimeout(function() {
-						image.classList.toggle('transparent', false);
+						image.toggleClass('transparent', false);
 					}, 300);
 				} else if (icon && image) {
 					icon.removeAttribute('hidden');

--- a/test/d2l-user-switcher.js
+++ b/test/d2l-user-switcher.js
@@ -144,7 +144,7 @@ describe('d2l-user-switcher', function() {
 					beforeEach(function() {
 						hasUsersTemplate.render();
 						defaultIcon = componentQuerySelector('d2l-icon.d2l-user-switcher-opener-image');
-						customImage = componentQuerySelector('img.d2l-user-switcher-opener-image');
+						customImage = componentQuerySelector('d2l-image.d2l-user-switcher-opener-image');
 					});
 
 					describe('has custom profile picture', function() {


### PR DESCRIPTION
[US98914 - Revert removal of d2l-image from user-tile, user-switcher, and folio](https://rally1.rallydev.com/#/157196228032d/detail/userstory/240154782788)

This reverts the changes from #41  because we still need to use tokens until we can fix issues with vanity URLs not using the same cookies as the domain returned by our hypermedia APIs. 