### PR TITLE
switching to our fork of app-localize-behavior

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "type-detect": "1.0.0"
   },
   "dependencies": {
-    "@polymer/app-localize-behavior": "^3.0.0",
+    "@polymer/app-localize-behavior": "BrightspaceUI/app-localize-behavior#v3.0.1-d2l",
     "d2l-colors": "BrightspaceUI/colors#semver:^4",
     "d2l-dropdown": "BrightspaceUI/dropdown#semver:^7",
     "d2l-hypermedia-constants": "Brightspace/d2l-hypermedia-constants#semver:^6",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "polymer-cli": "^1.9.5",
     "wct-browser-legacy": "^1.0.1"
   },
-  "version": "4.0.6",
+  "version": "4.0.7",
   "resolutions": {
     "inherits": "2.0.3",
     "samsam": "1.1.3",


### PR DESCRIPTION
As discussed, this switches things to use our fork of `app-localize-behavior`, which uses an updated `intl-messageformat`. I'll merge this in tandem with [a change to d2l-localize-behavior](https://github.com/BrightspaceUI/localize-behavior/pull/30) so as to avoid duplicate copies.