### PR TITLE
switching to use d2l-localize-behavior's copy of app-localize-behavior

### DIFF
--- a/localize-behavior.js
+++ b/localize-behavior.js
@@ -1,4 +1,4 @@
-import { AppLocalizeBehavior } from '@polymer/app-localize-behavior/app-localize-behavior.js';
+import { AppLocalizeBehavior } from 'd2l-localize-behavior/app-localize-behavior.js';
 import './lang/ar.js';
 import './lang/en.js';
 import './lang/es.js';

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "polymer-cli": "^1.9.5",
     "wct-browser-legacy": "^1.0.1"
   },
-  "version": "4.0.7",
+  "version": "4.0.8",
   "resolutions": {
     "inherits": "2.0.3",
     "samsam": "1.1.3",
@@ -47,12 +47,12 @@
     "type-detect": "1.0.0"
   },
   "dependencies": {
-    "@polymer/app-localize-behavior": "BrightspaceUI/app-localize-behavior#v3.0.1-d2l",
     "d2l-colors": "BrightspaceUI/colors#semver:^4",
     "d2l-dropdown": "BrightspaceUI/dropdown#semver:^7",
     "d2l-hypermedia-constants": "Brightspace/d2l-hypermedia-constants#semver:^6",
     "d2l-icons": "BrightspaceUI/icons#semver:^6",
     "d2l-image": "Brightspace/d2l-image#semver:^3",
+    "d2l-localize-behavior": "BrightspaceUI/localize-behavior#semver:^2",
     "d2l-menu": "BrightspaceUI/menu#semver:^2",
     "d2l-user-profile-behavior": "Brightspace/user-profile-behavior#semver:^4",
     "@polymer/iron-icon": "^3.0.0",


### PR DESCRIPTION
We ran into an issue with using the fork, where Windows machines blew up installing app-localize-behavior as a GitHub reference. Turned out to be easier to copy it into d2l-localize-behavior and have folks reference it from there.